### PR TITLE
Squirrel artist credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,17 @@ The testing suite is very small at the moment (about 7 tests).
 We need help in making it robust and exhaustive. Any contribution on this regard is highly appreciated.
 
 `squirrel` is still in an experimental stage. Bugs are probably present, so any testing and bug reporting is welcome.
+
+### Credit
+`Squirrel art` created by [Joan G. Stark](https://en.wikipedia.org/wiki/Joan_Stark) who is known in the ASCII world with the initials `jgs`.
+
+                               _
+                          .-'` `}
+                  _./)   /       }
+                .'o   \ |       }
+                '.___.'`.\    {`
+                /`\_/  , `.    }
+                \=' .-'   _`\  {
+                 `'`;/      `,  }
+                    _\       ;  }
+               jgs /__`;-...'--'

--- a/squirrel/vars.py
+++ b/squirrel/vars.py
@@ -19,8 +19,7 @@ ignore_file_path = IGNORE_FILENAME
 
 PLUGIN_PATH = 'plugins/'
 
-# TODO: find artist and credit him
-squirrel_art = """
+squirrel_art = r"""
                               _
                           .-'` `}
                   _./)   /       }
@@ -30,7 +29,7 @@ squirrel_art = """
                 \=' .-'   _`\  {
                  `'`;/      `,  }
                     _\       ;  }
-                   /__`;-...'--'
+               jgs /__`;-...'--'
 """
 
 ignore_file_content = """\


### PR DESCRIPTION
Added the artist's initials for `var.py` and upaded `squirrel_art` to a raw string. 

Normally with tox it would throw: `DeprecationWarning: invalid escape sequence '\ '
    squirrel_art = """`

Closed #26 by accident when I removed the commit from the PR.